### PR TITLE
only add category if we have a name to match fixed 'can create post w…

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,8 +7,10 @@ class Post < ActiveRecord::Base
 
   def categories_attributes=(category_attributes)
     category_attributes.values.each do |category_attribute|
-      category = Category.find_or_create_by(category_attribute)
-      self.categories << category
+      if category_attribute["name"].present?
+        category = Category.find_or_create_by(category_attribute)
+        self.categories << category
+      end
     end
   end
 end

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -13,8 +13,8 @@ describe 'Posts', type: 'feature' do
 
     it 'can create a post without a new category' do
       click_button('Create Post')
-      @category = Post.last.categories.first.name
-      expect(@category).to be_empty
+      @categories = Post.last.categories
+      expect(@categories).to be_empty
       expect(page).to have_content('Feeling Awesome')
     end
 


### PR DESCRIPTION
categories should be empty if we don't get a name, before it was expecting to still create a category but have an empty name
only add category if we have a name to match fixed 'can create post w/out category' test
@sgharms 