### PR TITLE
categories should be empty when we don't receive a name, not have a c…

### DIFF
--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -13,8 +13,8 @@ describe 'Posts', type: 'feature' do
 
     it 'can create a post without a new category' do
       click_button('Create Post')
-      @category = Post.last.categories.first.name
-      expect(@category).to be_empty
+      @categories = Post.last.categories
+      expect(@categories).to be_empty
       expect(page).to have_content('Feeling Awesome')
     end
 


### PR DESCRIPTION
categories should be empty when we don't receive a name, not have a category without a name
@sgharms 
see https://github.com/learn-co-curriculum/has-many-through-forms-rails-labs/pull/15 for proposed solution